### PR TITLE
Fix add host and allow_unsafe_werkzeug arguments to sockerio.run()

### DIFF
--- a/application.py
+++ b/application.py
@@ -22,7 +22,7 @@ app.config["DEBUG"] = False
 app.config["SEND_FILE_MAX_AGE_DEFAULT"] = -1
 
 # turn the flask app into a socketio app
-socketio = SocketIO(app, async_mode="threading", logger=True, engineio_logger=True)
+socketio = SocketIO(app, async_mode="eventlet", logger=True, engineio_logger=True)
 
 # random number Generator Thread
 thread = Thread()
@@ -271,4 +271,4 @@ def new_log_entry():
 
 
 if __name__ == "__main__":
-    socketio.run(app, port=8080, host='0.0.0.0', allow_unsafe_werkzeug=True)
+    socketio.run(app, port=8080, host="0.0.0.0")

--- a/application.py
+++ b/application.py
@@ -271,4 +271,4 @@ def new_log_entry():
 
 
 if __name__ == "__main__":
-    socketio.run(app, port=8080)
+    socketio.run(app, port=8080, host='0.0.0.0', allow_unsafe_werkzeug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ bleach
 Flask==2.2.2
 Flask-SocketIO==5.3.2
 Werkzeug==2.2.2
+eventlet


### PR DESCRIPTION
When starting the swap-it-dashboard with all installed dependencies as specified in the Readme.md, i receive the following error:

Server initialized for threading.
Traceback (most recent call last):
  File "/dashboard/application.py", line 274, in <module>
    socketio.run(app, port=8080)
  File "/usr/local/lib/python3.11/dist-packages/flask_socketio/__init__.py", line 641, in run
    raise RuntimeError('The Werkzeug web server is not '
RuntimeError: The Werkzeug web server is not designed to run in production. Pass allow_unsafe_werkzeug=True to the run() method to disable this error.

Error can be fixed by adding the allow_unsafe_werkzeug=True argument.

Besides, adding the host argument to socketio.run() enables the use of the dashboard within a docker-compose project, since custom hosts can be specified for docker-compose

