### PR TITLE
Remove dependency versioning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: CC0-1.0
 
 bleach
-Flask==2.2.2
-Flask-SocketIO==5.3.2
-Werkzeug==2.2.2
+Flask
+Flask-SocketIO
 eventlet


### PR DESCRIPTION
- With the use of eventlet, the newest versions of Flask and SocketIO no longer cause any errors